### PR TITLE
fix float complaint

### DIFF
--- a/teg/lang/base.py
+++ b/teg/lang/base.py
@@ -4,7 +4,7 @@ import numpy as np
 
 
 def try_making_teg_const(x):
-    if type(x) in (int, float, np.int64, np.float, np.float64):
+    if type(x) in (int, float, np.int64, np.float32, np.float64):
         x = Const(x)
     return x
 


### PR DESCRIPTION
Old error:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/alecjacobson/Repos/Teg/teg/__init__.py", line 1, in <module>
    from .lang.base import *
  File "/Users/alecjacobson/Repos/Teg/teg/lang/base.py", line 189, in <module>
    true = Bool(Const(0), Const(1))
  File "/Users/alecjacobson/Repos/Teg/teg/lang/base.py", line 169, in __init__
    super(Bool, self).__init__(children=[try_making_teg_const(e) for e in (left_expr, right_expr)])
  File "/Users/alecjacobson/Repos/Teg/teg/lang/base.py", line 169, in <listcomp>
    super(Bool, self).__init__(children=[try_making_teg_const(e) for e in (left_expr, right_expr)])
  File "/Users/alecjacobson/Repos/Teg/teg/lang/base.py", line 7, in try_making_teg_const
    if type(x) in (int, float, np.int64, np.float, np.float64):
  File "/Users/alecjacobson/miniconda3/lib/python3.9/site-packages/numpy/__init__.py", line 324, in __getattr__
    raise AttributeError(__former_attrs__[attr])
AttributeError: module 'numpy' has no attribute 'float'.
`np.float` was a deprecated alias for the builtin `float`. To avoid this error in existing code, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

```

I'm using python 3.9 with numpy 1.26.2